### PR TITLE
Visibility classes rework

### DIFF
--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -35,7 +35,7 @@ This example shows the opposite: It uses the `.hide` visibility classes to state
 
 ```html_example
 <p class="hide-for-medium">You are <em>not</em> on a medium screen or larger.</p>
-<p class="hide-for-large">You are <em>not</em> on a small screen or larger.</p>
+<p class="hide-for-large">You are <em>not</em> on a large screen or larger.</p>
 ```
 
 Like with `.show`, these classes also have `-only` versions.

--- a/scss/components/_visibility.scss
+++ b/scss/components/_visibility.scss
@@ -10,10 +10,8 @@
 /// @param {Keyword} $size - Breakpoint name or screen width to use.
 /// @param {Keyword} $prop [block] - The `display` property to use to un-hide the element.
 @mixin show-for($size, $prop: block) {
-  display: none !important;
-
-  @include breakpoint($size) {
-    display: $prop !important;
+  @include breakpoint($size down-excl) {
+    display: none !important;
   }
 }
 
@@ -21,10 +19,8 @@
 /// @param {Keyword} $size - Breakpoint name to use.
 /// @param {Keyword} $prop [block] - The `display` property to use to un-hide the element.
 @mixin show-for-only($size, $prop: block) {
-  display: none !important;
-
-  @include breakpoint($size only) {
-    display: $prop !important;
+  @include breakpoint($size down-excl, $size up-excl) {
+    display: none !important;
   }
 }
 

--- a/scss/util/_breakpoint.scss
+++ b/scss/util/_breakpoint.scss
@@ -58,7 +58,14 @@ $breakpoint-classes: (small medium large) !default;
         }
       }
 
-      $bp: map-get($breakpoints, $bp);
+      @if $dir == 'up-excl' {
+        $bp: -zf-map-next($breakpoints, $bp);
+        $dir: 'up';
+      }
+      @else {
+        $bp: map-get($breakpoints, $bp);
+      }
+
       $named: true;
     }
     @else {
@@ -70,6 +77,13 @@ $breakpoint-classes: (small medium large) !default;
   $bp: -zf-bp-to-em($bp);
   @if $bp-max {
     $bp-max: -zf-bp-to-em($bp-max) - (1/16);
+  }
+
+  // 'down-excl' is a special modifier excludes the range of a named breakpoint
+  @if $dir == 'down-excl' {
+    $bp: $bp - (1/16);
+    $dir: 'down';
+    $named: false;
   }
 
   // Skip media query creation if the input is "0 up" or "0 down"
@@ -92,7 +106,6 @@ $breakpoint-classes: (small medium large) !default;
     @else if $dir == 'down' {
       $max: 0;
 
-      // For named breakpoints, subtract the breakpoint value by one "pixel", or 1/16em.
       @if $named {
         $max: $bp-max;
       }

--- a/spec/scss/_breakpoint.scss
+++ b/spec/scss/_breakpoint.scss
@@ -30,6 +30,20 @@
     @include should(expect($actual), to(be($expected)));
   }
 
+  @include it("creates an exclusive down range out of a named breakpoint") {
+    $actual: breakpoint(medium down-excl);
+    $expected: '(max-width: 39.9375em)';
+
+    @include should(expect($actual), to(be($expected)));
+  }
+
+  @include it("creates an up range using the next breakpoint after a named one") {
+    $actual: breakpoint(medium up-excl);
+    $expected: '(min-width: 64em)';
+
+    @include should(expect($actual), to(be($expected)));
+  }
+
   @include it("creates a down range out of a pixel, rem or em value") {
     $expected: '(max-width: 1em)';
 


### PR DESCRIPTION
We want to rework visibility classes to not require the use of `display: block`. For example, `.show-for-medium` would look like this:

``` css
@media screen and (max-width: 39.9375em) {
  .show-for-medium { display: none; }
}
```

By using `max-width` instead of `min-width`, you don't need to use `display: block`.

Needs to work with:
- [x] `.show-for-*`
- [ ] `.show-for-*-only`

Also, if there are any instances of media queries being duplicated, we should find some clever way to merge them.
