### PR TITLE
Fix Source Ordering example in Flex Grid docs.

### DIFF
--- a/docs/pages/flex-grid.md
+++ b/docs/pages/flex-grid.md
@@ -238,11 +238,11 @@ We have a set of classes that make it easy to setup source ordering in your HTML
 
 ```html_example
 <div class="row">
-  <div class="column order-2 medium-order-1">
-    This column will come second on small, and first on medium and larger.
+  <div class="column order-1 medium-order-2">
+    This column will come first on small, and second on medium and larger.
   </div>
   <div class="column order-2 medium-order-1">
-    This column will come first on small, and second on medium and larger.
+    This column will come second on small, and first on medium and larger.
   </div>
 </div>
 ```


### PR DESCRIPTION
The existing example had identical `order-1 medium-order-2` classes for both DIVs. It also seems that the order the ordering classes appear in the markup matters. For example:

```
<!-- This works -->
<div class="column order-1 medium-order-2">
  This column will come first on small, and second on medium and larger.
</div>
<div class="column order-2 medium-order-1">
  This column will come second on small, and first on medium and larger.
</div>
```

```
<!-- This does not, the medium state never shows -->
<div class="column order-2 medium-order-1">
  This column will come second on small, and first on medium and larger.
</div>
<div class="column order-1 medium-order-2">
  This column will come first on small, and second on medium and larger.
</div>
```

It might be worth adding a note about the importance of the order of 'order' classes. If someone can do that without totally confusing everyone! ;)
