### PR TITLE
Accessible tabs

### DIFF
--- a/js/foundation.tabs.js
+++ b/js/foundation.tabs.js
@@ -48,7 +48,6 @@
       $link.attr({
         'role': 'tab',
         'aria-controls': hash,
-        'tabindex': $link.attr('tabindex') || tabIndex,
         'aria-selected': isActive,
         'id': linkId
       });


### PR DESCRIPTION
Removed tabindex attribute of the links.
Links should not have this attribute set because this causes jumping between different sets of tabs on the page.
Instead since the links are in the correct order they are already handled correctly when tabbing.
