### PR TITLE
Add bower install command to dev setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The Sass is compiled using libsass, which requires the GCC to be installed on yo
 ```bash
 git clone https://github.com/zurb/foundation-sites-6.git
 cd foundation-sites-6
+npm install -g bower
 npm install && bower install
 npm start
 ```


### PR DESCRIPTION
For completeness, I added the command needed to globally install bower, so `bower install` would work.
