### PR TITLE
Fixed bug with keyboard interaction and double-handled-slider

### DIFF
--- a/js/foundation.range-slider.js
+++ b/js/foundation.range-slider.js
@@ -211,7 +211,7 @@
     }
     $handle.on('keydown.zf.slider', function(e){
       var keyCode = e.keyCode || e.which,
-        idx = _this.options.doubleSided ? this.handles.index($(this)) : 0,
+        idx = _this.options.doubleSided ? _this.handles.index($(this)) : 0,
         oldValue = Number(_this.inputs.eq(idx).val()),
         newValue;
       if (keyCode === 37 || keyCode === 40) { // left or down arrow


### PR DESCRIPTION
There was a wrong object reference causing errors when using keyboard on two handles...
