### PR TITLE
Visibility - add tabindex to skip links example - update skip link ma…

### DIFF
--- a/docs/pages/visibility.md
+++ b/docs/pages/visibility.md
@@ -103,16 +103,16 @@ To hide text from assistive technology, while still keeping it visible, add the 
 
 If your site has a lot of navigation, a screen reader will have to read through the entire navigation to get to your site's content. To remedy this, you can add a *skip link* at the very top of your page, which will send the user farther down the page, past the navigation when clicked on.
 
-Use the class `.show-on-focus` to hide an element, except when it has focus.
+Use the class `.show-on-focus` to hide an element, except when it has focus. Adding tabindex="0" to the target element makes if focusable.
 
 ```html_example
 <p><a class="show-on-focus" href="#mainContent">Skip to Content</a></p>
 
-<header id="header">
-  
+<header id="header" role="banner">
+
 </header>
 
-<div id="mainContent" role="main">
-  
-</div>
+<main id="mainContent" role="main" tabindex="0">
+
+</main>
 ```


### PR DESCRIPTION
Skip links can benefit from adding tabindex="0" or tabindex="-1" on the target container. This is currently required for Chrome to send focus to the target div when the skip link is interacted with.

You can see this in action with these two demos below while using Chrome:
1. Skip link with no tabindex on target:
   http://codepen.io/joe-watkins/pen/cc126b896f64891ca30b3936f9e08539

In this demo you will see that when you tab into the interface and click skip link focus is not sent to the target div. You would expect to jump the navigation but you don't.
1. Skip link with tabindex on target: 
   http://codepen.io/joe-watkins/pen/dd35ddbbcde9aaea957587c3a62c1cb8

Also, if we are using HTML5 tags in code examples I included the `<main>` tag. It's a debated topic but it is still a good idea to keep the role on the tag for wider browser/AT support.
