### PR TITLE
Remove superfluous "within Foundation".

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -38,23 +38,23 @@ $warning-color: #ffae00 !default;
 /// @type Color
 $alert-color: #ec5840 !default;
 
-/// Color used for light gray UI items within Foundation.
+/// Color used for light gray UI items.
 /// @type Color
 $light-gray: #f3f3f3 !default;
 
-/// Color used for medium gray UI items within Foundation.
+/// Color used for medium gray UI items.
 /// @type Color
 $medium-gray: #cacaca !default;
 
-/// Color used for dark gray UI items within Foundation.
+/// Color used for dark gray UI items.
 /// @type Color
 $dark-gray: #8a8a8a !default;
 
-/// Color used for black ui items within Foundation
+/// Color used for black ui items.
 /// @type Color
 $black: #0a0a0a !default;
 
-/// Color used for white ui items within Foundation
+/// Color used for white ui items.
 /// @type Color
 $white: #fefefe !default;
 


### PR DESCRIPTION
Easier to read docs' SASS Reference Variables table. 
Removes confusion re: UI items within (or NOT within?) Foundation.
