### PR TITLE
Improved keyboard controls for accordion

### DIFF
--- a/js/foundation.accordion.js
+++ b/js/foundation.accordion.js
@@ -62,11 +62,21 @@
             _this.down($tabContent);
           }
         }).on('keydown.zf.accordion', function(e){
-          e.preventDefault();
-          e.stopPropagation();
           Foundation.handleKey(e, _this, {
             toggle: function() {
               _this.toggle($tabContent);
+            },
+            next: function() {
+              console.log( $tabContent.parent(),$tabContent.parent().next());
+              $tabContent.parent().next().find('a').focus().trigger('click.zf.accordion');
+            },
+            previous: function() {
+              $tabContent.parent().prev().find('a').focus().trigger('click.zf.accordion');
+
+            },
+            handled: function() {
+              e.preventDefault();
+              e.stopPropagation();
             }
           });
         });

--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -95,7 +95,7 @@
       'ENTER': 'toggle',
       'SPACE': 'toggle',
       'ARROW_DOWN': 'next',
-      'ARROW_UP': 'prev'
+      'ARROW_UP': 'previous'
 
     },
     'DropdownMenu': {


### PR DESCRIPTION
Moved preventDefault to the keyboard utils handled function
Added next and previous to support arrow navigation between tabs

Addressed to fix #159. I know that @zurbchris was planning something for #132, so please check if my PR is still necessary for #159.
