### PR TITLE
Fixed regex to get component name

### DIFF
--- a/js/foundation.core.js
+++ b/js/foundation.core.js
@@ -240,6 +240,9 @@ function functionName(fn) {
     var results = (funcNameRegex).exec((fn).toString());
     return (results && results.length > 1) ? results[1].trim() : "";
   }
+  else if (fn.prototype === undefined) {
+    return fn.constructor.name;
+  }
   else {
     return fn.prototype.constructor.name;
   }

--- a/js/foundation.drilldown.js
+++ b/js/foundation.drilldown.js
@@ -22,7 +22,7 @@
     this._init();
 
     Foundation.registerPlugin(this);
-    Foundation.registerKeyCommands('Drilldown', {
+    Foundation.Keyboard.register('Drilldown', {
       'ENTER': 'open',
       'SPACE': 'open',
       'ARROW_RIGHT': 'next',
@@ -141,7 +141,7 @@
           return;
         }
       });
-      Foundation.handleKey(e, _this, {
+      Foundation.Keyboard.handleKey(e, _this, {
         next: function() {
           if ($element.is(_this.$submenuAnchors)) {
             _this._show($element);

--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -105,7 +105,7 @@
    * @return String componentName
    */
   var getComponentName = function(component) {
-    return (/function (.+)\(/).exec((component).constructor.toString())[1] || '';
+    return (/function (\w+)\(/).exec((component).constructor.toString())[1] || '';
   };
 
 }(jQuery, window.Foundation);

--- a/js/foundation.util.keyboard.js
+++ b/js/foundation.util.keyboard.js
@@ -55,7 +55,7 @@
    * @param {Objects} functions - collection of functions that are to be executed
    */
   var handleKey = function(event, component, functions) {
-    var commandList = commands[getComponentName(component)],
+    var commandList = commands[Foundation.getFnName(component)],
       keyCode = parseKey(event),
       cmds,
       command,
@@ -98,14 +98,4 @@
     commands[componentName] = cmds;
   };
   Foundation.Keyboard.register = register;
-
-  /**
-   * Returns the component name name
-   * @param {Object} component - Foundation component, e.g. Slider or Reveal
-   * @return String componentName
-   */
-  var getComponentName = function(component) {
-    return (/function (\w+)\(/).exec((component).constructor.toString())[1] || '';
-  };
-
 }(jQuery, window.Foundation);


### PR DESCRIPTION
This caused the minified version used in the online docs to fail keyboard support.
See #223.