### PR TITLE
Documentation: [Sass] Fix spelling of Foundation + more

### DIFF
--- a/docs/pages/sass-functions.md
+++ b/docs/pages/sass-functions.md
@@ -1,7 +1,7 @@
 ---
 title: Sass Functions
-description: Behind the scenes, Foundation is powered by a set of utilty Sass functions that help us work with colors, units, selectors, and more.
-sass: 
+description: Behind the scenes, Foundation is powered by a set of utility Sass functions that help us work with colors, units, selectors, and more.
+sass:
   - scss/util/*.scss
   - '!scss/util/_breakpoint.scss'
   - '!scss/util/_mixins.scss'

--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -7,7 +7,7 @@ description: Foundation is written in Sass, which allows us to make the codebase
   <p>Not familiar with Sass? The [official tutorial](http://sass-lang.com/guide) on sass-lang.com is a great place to start.</p>
 </div>
 
-## Compatability
+## Compatibility
 
 <img src="assets/img/logo-sass.svg" alt="Sass logo" class="float-right" style="width: 150px; height: 150px; margin-left: 1rem;">
 

--- a/docs/pages/sass.md
+++ b/docs/pages/sass.md
@@ -109,7 +109,7 @@ Our [starter projects](starter-projects.html) include the full list of imports, 
 
 ## The Settings File
 
-All Foundatiion projects include a settings file, named `_settings.scss`. If you're using one of our starter projects, you can find the settings file under src/assets/scss/. If you're installing the framework standalone using Bower or npm, there's a settings file included in those packages, which you can move into your own Sass files to work with.
+All Foundation projects include a settings file, named `_settings.scss`. If you're using one of our starter projects, you can find the settings file under src/assets/scss/. If you're installing the framework standalone using Bower or npm, there's a settings file included in those packages, which you can move into your own Sass files to work with.
 
 Every component includes a set of variables that modify core structural or visual styles. If there's something you can't customize with a variable, you can just write your own CSS to add it.
 


### PR DESCRIPTION
Just a **minimal** fix for the word "compatibility" in the Sass Doc. ::smiley::

![fix-spelling-compat](https://cloud.githubusercontent.com/assets/5192517/11021345/8fa586de-85f3-11e5-8f59-60ff7a056590.png)

![fix-spelling-of-foundation](https://cloud.githubusercontent.com/assets/5192517/11021531/de45b4d0-85f8-11e5-957f-a330cf4af9b0.png)

![fix-spelling-of-utility](https://cloud.githubusercontent.com/assets/5192517/11021545/38925740-85f9-11e5-9843-1c7543e4d56c.png)
