### PR TITLE
Documentation: [Search] Make search more prominent

### DIFF
--- a/docs/assets/scss/_search.scss
+++ b/docs/assets/scss/_search.scss
@@ -3,6 +3,7 @@
 .twitter-typeahead {
   display: block !important;
   position: relative;
+  margin-top: 0.5rem;
 
   &::before {
     content: "\f16c";

--- a/docs/layout/default.html
+++ b/docs/layout/default.html
@@ -30,10 +30,9 @@
         </ul>
       </div>
 
-      <input type="text" class="docs-search" data-docs-search placeholder="Find a page, component, variable, mixin, function...">
-
       <div class="expanded row">
         <div class="medium-9 large-10 medium-push-3 large-push-2 columns">
+            <input type="text" class="docs-search" data-docs-search placeholder="Find a page, component, variable, mixin, function...">
 {{> body}}
         </div>
         <div class="medium-3 large-2 medium-pull-9 large-pull-10 columns">


### PR DESCRIPTION
## Goal
Currently, the new docs search is not easy to see. This may just be because our eyes are drawn to the blue callout box re: public beta.
Put this PR seeks to make the search box more prominent, even when the blue callout box is removed.

## Approach
* Moves the new search to just above the main body.
* Separates the top nav from the awesome new search.

Would definitely love to hear thoughts on this... :smiley:

## Screenshot
![make-search-more-prominent](https://cloud.githubusercontent.com/assets/5192517/11021757/1ad51136-8601-11e5-8cd6-890b380f20e7.png)