### PR TITLE
Keeps $menu-item-padding from being overridden by padding-top/bottom

### DIFF
--- a/scss/components/_menu.scss
+++ b/scss/components/_menu.scss
@@ -144,9 +144,9 @@ $menu-expand-max: 6 !default;
   font-weight: bold;
   color: inherit;
   line-height: 1;
-  padding: $menu-item-padding;
   padding-top: 0;
   padding-bottom: 0;
+  padding: $menu-item-padding;
 }
 
 @mixin foundation-menu {


### PR DESCRIPTION
Addresses Issue https://github.com/zurb/foundation-sites-6/issues/242.

$menu-item-padding was being overridden by padding-top and padding-bottom.  