### PR TITLE
allow for rtl

### DIFF
--- a/scss/grid/_column.scss
+++ b/scss/grid/_column.scss
@@ -68,7 +68,7 @@
   padding-right: $gutter;
 
   &:last-child {
-    float: right;
+    float: $global-right;
   }
 }
 


### PR DESCRIPTION
by using the global-right variable instead of static coding it to 'right'