### PR TITLE
Responsive dropdown menus

### DIFF
--- a/js/foundation.dropdownMenu.js
+++ b/js/foundation.dropdownMenu.js
@@ -83,12 +83,12 @@
     this.$menuItems.children('a').attr('tabindex', -1);
     if(this.$element.hasClass(this.options.rightClass)){
       this.options.alignment = 'right';
-      this.$submenus.addClass('is-right-arrow');
+      this.$submenus.addClass('is-left-arrow opens-left');
     }else{
-      this.$submenus.addClass('is-left-arrow');
+      this.$submenus.addClass('is-right-arrow opens-right');
     }
     if(!this.vertical){
-      this.$tabs.removeClass('is-right-arrow is-left-arrow').addClass('is-down-arrow');
+      this.$tabs.removeClass('is-right-arrow is-left-arrow opens-left opens-right').addClass('is-down-arrow');
     }
 
     this.$tabs.each(function(){
@@ -315,11 +315,18 @@
     var clear = Foundation.ImNotTouchingYou($sub, null, true);
     if(!clear){
       if(this.options.alignment === 'left'){
-        $sub.removeClass('is-left-arrow').addClass('is-right-arrow');
+        $elem.removeClass('opens-left').addClass('opens-right');
       }else{
-        $sub.removeClass('is-right-arrow').addClass('is-left-arrow');
+        $elem.removeClass('opens-right').addClass('opens-left');
       }
       this.changed = true;
+
+      // still not clear, small screen, add inner class
+      clear = Foundation.ImNotTouchingYou($sub, null, true);
+      if (!clear) {
+        $elem.removeClass('opens-left opens-right').addClass('opens-inner');
+        this.changed = true;
+      }
     }
     $sub.css('visibility', '');
     /**
@@ -351,7 +358,7 @@
       //   console.log('true');
       //   $elems.blur();
       // }
-      $elems.removeClass('is-active').data('isClick', false)
+      $elems.removeClass('is-active opens-inner').data('isClick', false)
 
             .find('.is-active').removeClass('is-active').data('isClick', false).end()
 
@@ -361,9 +368,9 @@
       if(this.changed){
         //remove position class
         if(this.options.alignment === 'left'){
-          $elems.find('.is-right-arrow').removeClass('is-right-arrow').addClass('is-left-arrow');
+          $elems.find('.opens-right').removeClass('opens-right').addClass('opens-left');
         }else{
-          $elems.find('.is-left-arrow').removeClass('is-left-arrow').addClass('is-right-arrow');
+          $elems.find('.opens-left').removeClass('opens-left').addClass('opens-right');
         }
       }
       /**

--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -29,15 +29,27 @@ $dropdownmenu-min-width: 200px !default;
         &.is-down-arrow > a::after {
           @include css-triangle(5px, $anchor-color, down);
         }
-        &.is-right-arrow > a::after {
+        &.is-left-arrow > a::after {
           @include css-triangle(5px, $anchor-color, left);
           float: left;
           margin-left: 0;
           margin-right: 10px;
         }
-        &.is-left-arrow > a::after {
+        &.is-right-arrow > a::after {
           @include css-triangle(5px, $anchor-color, right);
         }
+      }
+
+      &.is-left-arrow.opens-inner .submenu{
+        right: 0;
+        left: auto;
+      }
+      &.is-right-arrow.opens-inner .submenu{
+        left: 0;
+        right: auto;
+      }
+      &.opens-inner .submenu {
+        top: 100%;
       }
     }
 
@@ -55,27 +67,28 @@ $dropdownmenu-min-width: 200px !default;
         width: 100%;
       }
 
-      &.is-right-arrow {
-        left: auto;
-        right: 100%;
-      }
-
       &.first-sub {
         top: 100%;
         left: 0;
         right: auto;
-
-        @if $dropdownmenu-arrows {
-          &.is-right-arrow{
-            left: auto;
-            right: 0;
-          }
-        }
       }
 
       &:not(.js-dropdown-nohover) > .has-submenu:hover > &,
       &.js-dropdown-active {
         display: block;
+      }
+    }
+
+    .has-submenu.opens-left .submenu {
+      left: auto;
+      right: 100%;
+    }
+
+    &.align-right {
+      .submenu.first-sub {
+        top: 100%;
+        left: auto;
+        right: 0;
       }
     }
 
@@ -89,13 +102,6 @@ $dropdownmenu-min-width: 200px !default;
       > li .submenu {
         top: 0;
         left: 100%;
-
-        @if $dropdownmenu-arrows {
-          &.is-right-arrow {
-            left: auto;
-            right: 100%;
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
Dropdown menus are now more useful on small screens. If the dropdown cannot fly out properly to either side, it will render right below the parent `li`.
Separated classes for arrow alignment and for submenu alignment to avoid confusion.
Alignment classes are now all applied to the `.has-submenu` instead of the submenu itself.
Addresses #226.