### PR TITLE
Remove white space declaration

### DIFF
--- a/scss/components/_dropdown-menu.scss
+++ b/scss/components/_dropdown-menu.scss
@@ -47,7 +47,6 @@ $dropdownmenu-min-width: 200px !default;
       top: 0;
       left: 100%;
       min-width: $dropdownmenu-min-width;
-      white-space: nowrap;
       z-index: 1;
       background: white;
 


### PR DESCRIPTION
This fixes [issue 251](https://github.com/zurb/foundation-sites-6/issues/251)
I can't see any issues removing this, though long menu items will wrap around now.