### PR TITLE
Fix accordion-title CSS content character encoding

### DIFF
--- a/scss/components/_accordion.scss
+++ b/scss/components/_accordion.scss
@@ -81,7 +81,7 @@ $accordion-content-padding: 1rem !default;
     }
 
     .is-active > &::before {
-      content: '–';
+      content: '\2013';
     }
   }
 }


### PR DESCRIPTION
En dash used for accordion-title when expanded was encoded incorrectly and displayed gibberish. Now it's fixed.