### PR TITLE
Make drilldown submenus full height

### DIFF
--- a/scss/components/_drilldown.scss
+++ b/scss/components/_drilldown.scss
@@ -23,6 +23,7 @@ $drilldown-transition: transform 0.15s linear !default;
     top: 0;
     left: 100%;
     z-index: -1;
+    height: 100%;
     width: 100%;
     background: $white;
     transition: $drilldown-transition;


### PR DESCRIPTION
Short drilldown submenus need to extend 100% height to cover parent elements. See GIF for a better explanation of the problem.

![k0vohtfhax](https://cloud.githubusercontent.com/assets/6110968/11166887/e9e6dbe8-8b07-11e5-8d37-3b2aaef0951a.gif)
