### PR TITLE
var doesn't $root does not exist, using $base instead

### DIFF
--- a/scss/grid/_flex-grid.scss
+++ b/scss/grid/_flex-grid.scss
@@ -37,7 +37,7 @@
   margin-right: $margin;
 
   @if $columns != null {
-    @include grid-context($columns, $root) {
+    @include grid-context($columns, $base) {
       @content;
     }
   }


### PR DESCRIPTION
This causes a sass compilation error if you use the @mixin flex-grid-row() and set the columns to anything other than null. I assume that this should be set to $base.