### PR TITLE
Fixed getCurrentSize error when the matched variable is not an object

### DIFF
--- a/js/foundation.util.mediaQuery.js
+++ b/js/foundation.util.mediaQuery.js
@@ -92,7 +92,11 @@ var MediaQuery = {
       }
     }
 
-    return matched.name;
+    if(typeof matched === 'object') {
+      return matched.name;
+    } else {
+      return matched;
+    }
   },
 
   /**


### PR DESCRIPTION
Fixes https://github.com/zurb/foundation-sites-6/issues/286